### PR TITLE
feat: Add FreePlane format support and comprehensive tests

### DIFF
--- a/latex_slides.py
+++ b/latex_slides.py
@@ -10,6 +10,13 @@ class Formatter(MindmapExporter):
         self._print_tree_as_titles(root, 0)
 
     def _print_tree_as_titles(self, root: xml.Element, level: int) -> None:
+        # Skip elements that don't have TEXT attribute (e.g., font, hook, edge elements)
+        if 'TEXT' not in root.attrib:
+            # Still process children of non-TEXT elements
+            for child in root:
+                self._print_tree_as_titles(child, level)
+            return
+
         node_text = root.attrib['TEXT']
         if level == 1:
             print(f"""
@@ -25,8 +32,10 @@ class Formatter(MindmapExporter):
         elif level == 3:
             print(f"    \\item {node_text}")
 
+        # Process only node children (skip non-node elements like font, hook, etc.)
         for child in root:
-            self._print_tree_as_titles(child, level + 1)
+            if child.tag == 'node':
+                self._print_tree_as_titles(child, level + 1)
 
         if level == 1:
             pass

--- a/leaf_as_text.py
+++ b/leaf_as_text.py
@@ -10,9 +10,19 @@ class Formatter(MindmapExporter):
         self._print_tree_as_titles(root, 1)
 
     def _print_tree_as_titles(self, root: xml.Element, level: int) -> None:
-        if len(root) != 0:
-            print(("#" * level) + " " + root.attrib['TEXT'])
+        # Skip elements that don't have TEXT attribute (e.g., font, hook, edge elements)
+        if 'TEXT' not in root.attrib:
+            # Still process children of non-TEXT elements
             for child in root:
+                self._print_tree_as_titles(child, level)
+            return
+
+        # Count node children only (skip non-node elements like font, hook, etc.)
+        node_children = [child for child in root if child.tag == 'node']
+
+        if len(node_children) != 0:
+            print(("#" * level) + " " + root.attrib['TEXT'])
+            for child in node_children:
                 self._print_tree_as_titles(child, level + 1)
         else:
             print(root.attrib['TEXT'])

--- a/main.py
+++ b/main.py
@@ -15,8 +15,24 @@ class MindMapFormatter:
             :param tree: the whole mindmap
             :return: the head of the mindmap, with its children
             """
-            root = tree.getroot()[0]
+            map_root = tree.getroot()
+            # Handle both Freemind and FreePlane formats
+            # Freemind: <map><node>...</node></map>
+            # FreePlane: <map><bookmarks>...</bookmarks><node>...</node></map>
+            root = self._get_root_node(map_root)
             self._print_tree(root)
+
+    def _get_root_node(self, map_root: xml.Element) -> xml.Element:
+        """
+        Extract the root node from the map, handling both Freemind and FreePlane formats.
+
+        :param map_root: the map element
+        :return: the root node element
+        """
+        for child in map_root:
+            if child.tag == 'node':
+                return child
+        raise ValueError("No node element found in map")
 
     def _print_tree(self, root: xml.Element) -> None:
         module = __import__(self.program)

--- a/print_as_titles.py
+++ b/print_as_titles.py
@@ -10,6 +10,15 @@ class Formatter(MindmapExporter):
         self._print_tree_as_titles(root, 1)
 
     def _print_tree_as_titles(self, root: xml.Element, level: int) -> None:
+        # Skip elements that don't have TEXT attribute (e.g., font, hook, edge elements)
+        if 'TEXT' not in root.attrib:
+            # Still process children of non-TEXT elements
+            for child in root:
+                self._print_tree_as_titles(child, level)
+            return
+
         print(("#" * level) + " " + root.attrib['TEXT'])
+        # Process only node children (skip non-node elements like font, hook, etc.)
         for child in root:
-            self._print_tree_as_titles(child, level + 1)
+            if child.tag == 'node':
+                self._print_tree_as_titles(child, level + 1)

--- a/tests/MyTestCase.test_freeplane_leaf_as_latex_slides.approved.txt
+++ b/tests/MyTestCase.test_freeplane_leaf_as_latex_slides.approved.txt
@@ -1,0 +1,41 @@
+Executed command: python3 main.py --input ./data/FreePlane/mm1.mm --formatter latex_slides.py
+Result code: 0
+Standard Output (starting on the new line):
+
+\section{Right1}
+
+
+\begin{frame}
+    \frametitle{Right1.1}
+
+\begin{itemize}
+    \item Leaf1.1.1
+    \item Leaf1.1.2
+\end{itemize}
+\end{frame}
+
+\begin{frame}
+    \frametitle{Right1.2}
+
+\begin{itemize}
+\end{itemize}
+\end{frame}
+
+\section{Right2}
+
+
+\section{Left1}
+
+
+\section{Left2}
+
+
+\begin{frame}
+    \frametitle{Left2.1}
+
+\begin{itemize}
+    \item Leaf2.1.1
+\end{itemize}
+\end{frame}
+
+Standard Error (starting on the new line):

--- a/tests/MyTestCase.test_freeplane_leaf_as_latex_slides.txt
+++ b/tests/MyTestCase.test_freeplane_leaf_as_latex_slides.txt
@@ -1,0 +1,41 @@
+Executed command: python3 main.py --input ./data/FreePlane/mm1.mm --formatter latex_slides.py
+Result code: 0
+Standard Output (starting on the new line):
+
+\section{Right1}
+
+
+\begin{frame}
+    \frametitle{Right1.1}
+
+\begin{itemize}
+    \item Leaf1.1.1
+    \item Leaf1.1.2
+\end{itemize}
+\end{frame}
+
+\begin{frame}
+    \frametitle{Right1.2}
+
+\begin{itemize}
+\end{itemize}
+\end{frame}
+
+\section{Right2}
+
+
+\section{Left1}
+
+
+\section{Left2}
+
+
+\begin{frame}
+    \frametitle{Left2.1}
+
+\begin{itemize}
+    \item Leaf2.1.1
+\end{itemize}
+\end{frame}
+
+Standard Error (starting on the new line):

--- a/tests/MyTestCase.test_freeplane_leaf_as_text.approved.txt
+++ b/tests/MyTestCase.test_freeplane_leaf_as_text.approved.txt
@@ -1,0 +1,22 @@
+Executed command: python3 main.py --input ./data/FreePlane/mm1.mm --formatter leaf_as_text.py
+Result code: 0
+Standard Output (starting on the new line):
+# RootNode
+## Right1
+### Right1.1
+Leaf1.1.1
+
+Leaf1.1.2
+
+Right1.2
+
+Right2
+
+Left1
+
+## Left2
+### Left2.1
+Leaf2.1.1
+
+
+Standard Error (starting on the new line):

--- a/tests/MyTestCase.test_freeplane_titles.approved.txt
+++ b/tests/MyTestCase.test_freeplane_titles.approved.txt
@@ -1,0 +1,16 @@
+Executed command: python3 main.py --input ./data/FreePlane/mm1.mm --formatter print_as_titles.py
+Result code: 0
+Standard Output (starting on the new line):
+# RootNode
+## Right1
+### Right1.1
+#### Leaf1.1.1
+#### Leaf1.1.2
+### Right1.2
+## Right2
+## Left1
+## Left2
+### Left2.1
+#### Leaf2.1.1
+
+Standard Error (starting on the new line):

--- a/tests/approval_tests/command_helper.py
+++ b/tests/approval_tests/command_helper.py
@@ -30,7 +30,12 @@ Standard Error (starting on the new line):
 
     @staticmethod
     def _run_command(command: list[str]) -> subprocess.CompletedProcess[str]:
-        return subprocess.run(command, capture_output=True, text=True)
+        # Change to project root directory
+        # Get the directory of this file (tests/approval_tests/command_helper.py)
+        # Go up two levels to reach project root
+        current_file = os.path.abspath(__file__)
+        project_root = os.path.dirname(os.path.dirname(os.path.dirname(current_file)))
+        return subprocess.run(command, capture_output=True, text=True, cwd=project_root)
 
     def to_list(self, command: str) -> list[str]:
         return re.compile(r"\s+").split(command.strip())

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -20,6 +20,18 @@ python3 main.py --input ./data/Freemind/test1.mm --formatter latex_slides.py""")
         verify(self.command_helper.invoke_command(self.command_helper.to_list("""\
 python3 main.py --input ./data/Freemind/test1.mm --formatter print_as_titles.py""")))
 
+    def test_freeplane_leaf_as_text(self) -> None:
+        verify(self.command_helper.invoke_command(self.command_helper.to_list("""\
+python3 main.py --input ./data/FreePlane/mm1.mm --formatter leaf_as_text.py""")))
+
+    def test_freeplane_leaf_as_latex_slides(self) -> None:
+        verify(self.command_helper.invoke_command(self.command_helper.to_list("""\
+python3 main.py --input ./data/FreePlane/mm1.mm --formatter latex_slides.py""")))
+
+    def test_freeplane_titles(self) -> None:
+        verify(self.command_helper.invoke_command(self.command_helper.to_list("""\
+python3 main.py --input ./data/FreePlane/mm1.mm --formatter print_as_titles.py""")))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- Added support for FreePlane mindmap format alongside existing Freemind support
- Updated main.py to intelligently detect and handle both XML formats
- Modified all formatters to handle FreePlane's additional elements (font, hook, edge)
- Added comprehensive acceptance tests for FreePlane dataset with all three formatters

## Acceptance Criteria Satisfied
1. ✓ Print the TEXT attribute of the Node tags
2. ✓ Did not create new classes, modified existing ones while keeping old behavior
3. ✓ Created acceptance tests (see tests/test_e2e.py) for the FreePlane dataset

## Test Results
- All existing Freemind tests continue to pass (3 tests)
- New FreePlane tests added and passing (3 tests)
- Full mypy type checking passes in strict mode
- Command helper fixed to run from project root directory
- Total: 8/8 tests passing