### PR TITLE
Reorganize code into mindmap and worklog packages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,22 +69,34 @@ All 203 tests must pass.
 
 ## Code Organization
 
-### Value Objects (orgmode_dates.py)
-Frozen dataclasses representing immutable data:
-- `DateValue`, `DateTimeValue`: Date/time representations
-- `TimeEntry`, `Section`, `DateEntry`: Date reading structures
-- `TaskEntry`, `TaskInfo`, `ProjectInfo`: Task and project hierarchies
-- `DateReader`, `DateTimeReader`: Factory methods for XML parsing
+### mindmap Package
+Core mindmap reading and tree traversal:
+- `mindmap/reader.py`:
+  - `NodeTreeHelper`: Tree traversal and node classification (is_leaf, get_node_children, extract_tags_from_node)
+  - `DateReader`: XML date node reading and parsing
+  - `DateTimeReader`: XML datetime node reading and parsing
+- `mindmap/models.py`: Value objects representing immutable mindmap data
+  - `DateValue`: Date representation with formatting
+  - `DateTimeValue`: Datetime representation with formatting
+  - `TimeEntry`: Time entry with start/end times
+  - `Section`: Named section (WORKLOG, TIMES, TODO, etc.)
+  - `DateEntry`: Date with associated sections
 
-### Helper Classes (orgmode_helpers.py)
-Static utility methods organized by responsibility:
-- `NodeTreeHelper`: Tree traversal and node classification
-- `DateTimeHelper`: Datetime operations
-- `DurationFormatter`: Time duration calculations and formatting
-- `HierarchicalNodeProcessor`: Three-phase node processing
+### worklog Package
+Worklog-specific formatting and TODO logic:
+- `worklog/format.py`:
+  - `TodoHelper`: TODO detection and text processing (is_todo, clean_todo_text)
+- `worklog/helpers.py`:
+  - `DateTimeHelper`: Datetime operations (find_end_time, extract_comments)
+  - `DurationFormatter`: Time duration calculations and formatting
+  - `HierarchicalNodeProcessor`: Three-phase node processing
+- `worklog/models.py`: Value objects for worklog task and project data
+  - `TaskEntry`: Worklog entry with task name and time range
+  - `TaskInfo`: Task with multiple entries
+  - `ProjectInfo`: Project containing multiple tasks
 
-### Formatters
-- `orgmode.py`: Main ORGMode output formatter
+### Formatters (root level)
+- `orgmode.py`: Main ORGMode worklog output formatter
 - `orgmode_date_sections.py`: Date section formatting
 - `orgmode_lists.py`: List formatting
 

--- a/mindmap/__init__.py
+++ b/mindmap/__init__.py
@@ -1,0 +1,15 @@
+"""Mindmap reading and tree traversal utilities."""
+
+from mindmap.reader import NodeTreeHelper, DateReader, DateTimeReader
+from mindmap.models import DateValue, DateTimeValue, TimeEntry, Section, DateEntry
+
+__all__ = [
+    "NodeTreeHelper",
+    "DateReader",
+    "DateTimeReader",
+    "DateValue",
+    "DateTimeValue",
+    "TimeEntry",
+    "Section",
+    "DateEntry",
+]

--- a/mindmap/models.py
+++ b/mindmap/models.py
@@ -1,0 +1,80 @@
+"""Value objects for mindmap date and time data."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, date as DateType
+from typing import List
+
+import xml.etree.ElementTree as xml
+
+
+@dataclass(frozen=True)
+class DateValue:
+    """Represents a date extracted from a mindmap node."""
+
+    value: DateType
+
+    def format_header(self) -> str:
+        """Format date as ORGMode header: [YYYY-MM-DD Day]"""
+        return f"[{self.value.strftime('%Y-%m-%d %a')}]"
+
+
+@dataclass(frozen=True)
+class DateTimeValue:
+    """Represents a datetime extracted from a mindmap node."""
+
+    value: datetime
+
+    def format_time(self) -> str:
+        """Format time portion: HH:MM"""
+        return self.value.strftime("%H:%M")
+
+
+@dataclass(frozen=True)
+class TimeEntry:
+    """Represents a time entry in the TIMES section."""
+
+    start: DateTimeValue
+    end: DateTimeValue | None
+    description: str
+    tags: List[str]
+
+    def format_line(self) -> str:
+        """Format as ORGMode time entry: - HH:MM - HH:MM: description :tags:"""
+        start_str = self.start.format_time()
+        end_str = self.end.format_time() if self.end else "noend"
+
+        desc_clean = self.description.strip() if self.description else ""
+        tags_str = f" :{':'.join(self.tags)}:" if self.tags else ""
+
+        if desc_clean:
+            return f"- {start_str} - {end_str}: {desc_clean}{tags_str}"
+        else:
+            return f"- {start_str} - {end_str}{tags_str}"
+
+
+@dataclass(frozen=True)
+class Section:
+    """Represents a section (WORKLOG, TIMES, TODO, etc.) with its content."""
+
+    name: str
+    node: xml.Element
+
+    def is_times_section(self) -> bool:
+        return self.name == "TIMES"
+
+    def is_todo_section(self) -> bool:
+        return self.name == "TODO"
+
+
+@dataclass(frozen=True)
+class DateEntry:
+    """Represents a date with its associated sections."""
+
+    date: DateValue
+    sections: List[Section]
+
+    def sort_key(self) -> DateType:
+        """Return the date value for sorting."""
+        return self.date.value

--- a/orgmode.py
+++ b/orgmode.py
@@ -2,8 +2,9 @@ from mindmap_exporter import MindmapExporter
 import xml.etree.ElementTree as xml
 from datetime import datetime, date
 from typing import Optional, List, Dict, Any, Tuple
-from orgmode_dates import DateReader, DateTimeReader
-from orgmode_helpers import NodeTreeHelper, DurationFormatter
+from mindmap.reader import DateReader, DateTimeReader, NodeTreeHelper
+from worklog.helpers import DurationFormatter
+from worklog.format import TodoHelper
 
 
 class Formatter(MindmapExporter, NodeTreeHelper):
@@ -428,8 +429,8 @@ class Formatter(MindmapExporter, NodeTreeHelper):
         return NodeTreeHelper.is_leaf(node)
 
     def _is_todo(self, node: xml.Element) -> bool:
-        """Backward-compatible wrapper for NodeTreeHelper.is_todo()."""
-        return NodeTreeHelper.is_todo(node)
+        """Backward-compatible wrapper for TodoHelper.is_todo()."""
+        return TodoHelper.is_todo(node)
 
     def _get_node_children(self, node: xml.Element) -> List[xml.Element]:
         """Backward-compatible wrapper for NodeTreeHelper.get_node_children()."""

--- a/orgmode_date_sections.py
+++ b/orgmode_date_sections.py
@@ -3,15 +3,9 @@ import xml.etree.ElementTree as xml
 from datetime import datetime, date
 from typing import Optional, List, Any
 from html.parser import HTMLParser
-from orgmode_dates import (
-    DateReader,
-    DateTimeReader,
-    DateTimeValue,
-    TimeEntry,
-    Section,
-    DateEntry,
-)
-from orgmode_helpers import NodeTreeHelper
+from mindmap.reader import DateReader, DateTimeReader, NodeTreeHelper
+from mindmap.models import DateTimeValue, TimeEntry, Section, DateEntry
+from worklog.format import TodoHelper
 
 
 class Formatter(MindmapExporter, NodeTreeHelper):
@@ -159,11 +153,11 @@ class Formatter(MindmapExporter, NodeTreeHelper):
     ) -> None:
         """Format a node in TODO section as a header."""
         text = node.attrib.get("TEXT", "")
-        is_todo_marked = NodeTreeHelper.is_todo(node)
+        is_todo_marked = TodoHelper.is_todo(node)
 
         # Clean TODO marker if present
         if is_todo_marked:
-            text = NodeTreeHelper.clean_todo_text(text)
+            text = TodoHelper.clean_todo_text(text)
 
         # In TODO section: all items become TODO by default
         # unless marked with ! for explicit PROJ
@@ -318,7 +312,7 @@ class Formatter(MindmapExporter, NodeTreeHelper):
         leaf_non_todo = [
             c
             for c in children
-            if NodeTreeHelper.is_leaf(c) and not NodeTreeHelper.is_todo(c)
+            if NodeTreeHelper.is_leaf(c) and not TodoHelper.is_todo(c)
         ]
         for child in leaf_non_todo:
             self._format_node_hierarchical(
@@ -329,7 +323,7 @@ class Formatter(MindmapExporter, NodeTreeHelper):
         nonleaf_non_todo = [
             c
             for c in children
-            if not NodeTreeHelper.is_leaf(c) and not NodeTreeHelper.is_todo(c)
+            if not NodeTreeHelper.is_leaf(c) and not TodoHelper.is_todo(c)
         ]
         for child in nonleaf_non_todo:
             self._format_node_hierarchical(
@@ -337,7 +331,7 @@ class Formatter(MindmapExporter, NodeTreeHelper):
             )
 
         # Phase 3: TODO children
-        todos = [c for c in children if NodeTreeHelper.is_todo(c)]
+        todos = [c for c in children if TodoHelper.is_todo(c)]
         for child in todos:
             self._format_node_hierarchical(
                 child, lines, level, section_name=section_name
@@ -348,12 +342,12 @@ class Formatter(MindmapExporter, NodeTreeHelper):
     ) -> None:
         """Format a single node hierarchically."""
         text = node.attrib.get("TEXT", "")
-        is_todo = NodeTreeHelper.is_todo(node)
+        is_todo = TodoHelper.is_todo(node)
         is_leaf = NodeTreeHelper.is_leaf(node)
 
         # Clean TODO marker
         if is_todo:
-            text = NodeTreeHelper.clean_todo_text(text)
+            text = TodoHelper.clean_todo_text(text)
 
         # For non-leaf nodes at level 0 in WORKLOG or LEARNLOG, check if all children are leaves
         # If so, format as list items; otherwise, format as headers
@@ -361,7 +355,7 @@ class Formatter(MindmapExporter, NodeTreeHelper):
         if not is_leaf and level == 0 and section_name in ("WORKLOG", "LEARNLOG"):
             children = NodeTreeHelper.get_node_children(node)
             all_children_are_leaves = all(
-                NodeTreeHelper.is_leaf(c) or NodeTreeHelper.is_todo(c) for c in children
+                NodeTreeHelper.is_leaf(c) or TodoHelper.is_todo(c) for c in children
             )
             if all_children_are_leaves:
                 is_simple_node = True
@@ -487,8 +481,8 @@ class Formatter(MindmapExporter, NodeTreeHelper):
         return NodeTreeHelper.is_leaf(node)
 
     def _is_todo(self, node: xml.Element) -> bool:
-        """Backward-compatible wrapper for NodeTreeHelper.is_todo()."""
-        return NodeTreeHelper.is_todo(node)
+        """Backward-compatible wrapper for TodoHelper.is_todo()."""
+        return TodoHelper.is_todo(node)
 
     def _get_node_children(self, node: xml.Element) -> List[xml.Element]:
         """Backward-compatible wrapper for NodeTreeHelper.get_node_children()."""

--- a/orgmode_lists.py
+++ b/orgmode_lists.py
@@ -1,7 +1,8 @@
 from mindmap_exporter import MindmapExporter
 import xml.etree.ElementTree as xml
 from typing import List
-from orgmode_helpers import NodeTreeHelper
+from mindmap.reader import NodeTreeHelper
+from worklog.format import TodoHelper
 
 
 class Formatter(MindmapExporter, NodeTreeHelper):
@@ -23,12 +24,12 @@ class Formatter(MindmapExporter, NodeTreeHelper):
             return
 
         text = node.attrib["TEXT"]
-        is_todo = NodeTreeHelper.is_todo(node)
+        is_todo = TodoHelper.is_todo(node)
         is_leaf = NodeTreeHelper.is_leaf(node)
 
         # Clean up TODO marker from text if needed
         if is_todo:
-            text = NodeTreeHelper.clean_todo_text(text)
+            text = TodoHelper.clean_todo_text(text)
 
         # Determine what to add to lines
         if level == 1:
@@ -53,7 +54,7 @@ class Formatter(MindmapExporter, NodeTreeHelper):
         leaf_non_todo = [
             c
             for c in children
-            if NodeTreeHelper.is_leaf(c) and not NodeTreeHelper.is_todo(c)
+            if NodeTreeHelper.is_leaf(c) and not TodoHelper.is_todo(c)
         ]
         for child in leaf_non_todo:
             self._parse_node(child, level + 1)
@@ -62,13 +63,13 @@ class Formatter(MindmapExporter, NodeTreeHelper):
         nonleaf_non_todo = [
             c
             for c in children
-            if not NodeTreeHelper.is_leaf(c) and not NodeTreeHelper.is_todo(c)
+            if not NodeTreeHelper.is_leaf(c) and not TodoHelper.is_todo(c)
         ]
         for child in nonleaf_non_todo:
             self._parse_node(child, level + 1)
 
         # Phase 3: TODO children (leaf or non-leaf)
-        todos = [c for c in children if NodeTreeHelper.is_todo(c)]
+        todos = [c for c in children if TodoHelper.is_todo(c)]
         for child in todos:
             self._parse_node(child, level + 1)
 
@@ -79,8 +80,8 @@ class Formatter(MindmapExporter, NodeTreeHelper):
         return NodeTreeHelper.is_leaf(node)
 
     def _is_todo(self, node: xml.Element) -> bool:
-        """Backward-compatible wrapper for NodeTreeHelper.is_todo()."""
-        return NodeTreeHelper.is_todo(node)
+        """Backward-compatible wrapper for TodoHelper.is_todo()."""
+        return TodoHelper.is_todo(node)
 
     def _get_node_children(self, node: xml.Element) -> List[xml.Element]:
         """Backward-compatible wrapper for NodeTreeHelper.get_node_children()."""

--- a/worklog/__init__.py
+++ b/worklog/__init__.py
@@ -1,0 +1,15 @@
+"""Worklog formatting and TODO handling utilities."""
+
+from worklog.format import TodoHelper
+from worklog.helpers import DateTimeHelper, DurationFormatter, HierarchicalNodeProcessor
+from worklog.models import TaskEntry, TaskInfo, ProjectInfo
+
+__all__ = [
+    "TodoHelper",
+    "DateTimeHelper",
+    "DurationFormatter",
+    "HierarchicalNodeProcessor",
+    "TaskEntry",
+    "TaskInfo",
+    "ProjectInfo",
+]

--- a/worklog/format.py
+++ b/worklog/format.py
@@ -1,0 +1,22 @@
+"""TODO formatting and handling utilities."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as xml
+
+
+class TodoHelper:
+    """Helper class for TODO detection and text processing."""
+
+    @staticmethod
+    def is_todo(node: xml.Element) -> bool:
+        """Check if node text starts with '!' (TODO marker)."""
+        text = node.attrib.get("TEXT", "").strip()
+        return text.startswith("!")
+
+    @staticmethod
+    def clean_todo_text(text: str) -> str:
+        """Remove TODO marker ('!') from beginning of text."""
+        if text.strip().startswith("!"):
+            return text.strip()[1:].strip()
+        return text

--- a/worklog/models.py
+++ b/worklog/models.py
@@ -1,0 +1,38 @@
+"""Value objects for worklog task and project data."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, date as DateType
+from typing import List, Any
+
+
+@dataclass(frozen=True)
+class TaskEntry:
+    """Represents a worklog or time-tracking task entry."""
+
+    task_name: str
+    start: datetime
+    end: datetime | None
+    date: DateType
+    tags: List[str]
+    section_name: str = "WORKLOG"
+    comments: List[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class TaskInfo:
+    """Represents a task within a project with time entries."""
+
+    task_name: str
+    entries: List[dict[str, Any]]  # List of {start, end, comments}
+    tags: List[str]
+
+
+@dataclass(frozen=True)
+class ProjectInfo:
+    """Represents a project containing multiple tasks."""
+
+    name: str
+    tasks: List[TaskInfo]
+    tags: List[str]


### PR DESCRIPTION
**mindmap package**: Core mindmap reading and tree traversal
- mindmap/reader.py: NodeTreeHelper, DateReader, DateTimeReader
- mindmap/models.py: DateValue, DateTimeValue, TimeEntry, Section, DateEntry

**worklog package**: Worklog-specific formatting and TODO logic
- worklog/format.py: TodoHelper (is_todo, clean_todo_text)
- worklog/helpers.py: DateTimeHelper, DurationFormatter, HierarchicalNodeProcessor
- worklog/models.py: TaskEntry, TaskInfo, ProjectInfo

**Updates to formatters**:
- orgmode.py: Import from mindmap.reader, worklog.helpers, worklog.format
- orgmode_date_sections.py: Import from mindmap.reader, mindmap.models, worklog.format
- orgmode_lists.py: Import from mindmap.reader, worklog.format

**Benefits**:
- Clear separation of concerns (mindmap vs worklog)
- Easier to extend with new formatters or readers
- Better code organization following single responsibility principle
- All 203 tests pass with strict mypy type checking